### PR TITLE
9 create load workflow

### DIFF
--- a/oeps_backend/bq_load.py
+++ b/oeps_backend/bq_load.py
@@ -1,0 +1,138 @@
+import io
+import os
+import json
+import argparse
+import pandas as pd
+import geopandas as gpd
+
+from shapely import make_valid, is_valid, normalize, to_geojson
+from shapely.geometry import Polygon, MultiPolygon
+
+from google.cloud.bigquery import (
+    Table,
+    SchemaField,
+    LoadJobConfig,
+)
+
+from oeps_backend.utils import get_client, LOCAL_DATA_DIR
+
+def create_table(schema, overwrite=False):
+
+    project_id = os.getenv("BQ_PROJECT_ID")
+
+    #create big query client
+    client = get_client()
+
+    # make sure the dataset exists
+    client.create_dataset(schema['bq_dataset_name'], exists_ok=True)
+
+    field_list = []
+    for f in schema["fields"]:
+        max_length = f.get('max_length')
+        field_list.append(
+            SchemaField(
+                name=f["name"],
+                field_type=f["bq_data_type"],
+                max_length=max_length,
+            )
+        )
+
+    full_table_id = f"{project_id}.{schema['bq_dataset_name']}.{schema['bq_table_name']}"
+    if overwrite is True:
+        client.delete_table(full_table_id, not_found_ok=True)
+    table = client.create_table(
+        Table(full_table_id, schema=field_list),
+    )
+    print(f'Table created: {table.full_table_id}')
+    return table
+
+def load_table(schema):
+    """
+    Takes an input table_definition and loads the specified data source into
+    Google BigQuery, using the schema supplied. For spatial data, the BigQuery
+    GEOGRAPHY column must be named 'geom'.
+
+    The load mechanism used here is BQ's load_data_from_file, with a StringIO
+    object taking the place of an opened file. The StringIO object must contain
+    newline-delimited, stringified JSON objects. It took a long time to reach
+    that configuration successfully, because load_data_from_dataframe failed on
+    certain geometries without providing any way to debug which ones.
+    """
+
+    project_id = os.getenv("BQ_PROJECT_ID")
+
+    dataset_path = os.path.join(LOCAL_DATA_DIR, schema['data_source'])
+
+    client = get_client()
+
+    df = gpd.read_file(dataset_path)
+    print(df.head())
+
+    print("Preparing data frame...")
+    # use any src_name properties to rename columns where needed
+    field_mapping = {}
+    for f in schema['fields']:
+        src_name = f.get('src_name')
+        if src_name:
+             field_mapping[src_name] = f['name']
+    if field_mapping:
+        df.rename(columns=field_mapping, inplace=True)
+
+    # remove any input columns that are not in the schema
+    drop_columns = [i for i in df.columns if not i in field_mapping.values()]
+    df.drop(columns=drop_columns, inplace=True)
+
+    # iterate fields and zfill columns where needed
+    for f in schema['fields']:
+        if f.get('zfill', False) is True:
+            if df.dtypes[f['name']] == 'float64':
+                df[f['name']] = df[f['name']].apply(lambda x: str(int(x)).zfill(f['max_length']))
+            else:
+                df[f['name']] = df[f['name']].apply(lambda x: str(x).zfill(f['max_length']))
+
+    print(df.head())
+
+    rows = []
+    for i in df.index:
+        row = {col: df.at[i, col] for col in df.columns}
+        if 'geom' in df.columns:
+            row['geom'] = json.dumps(df.at[i, 'geom'].__geo_interface__)
+        rows.append(json.dumps(row))
+
+    print(f"Input rows: {len(rows)}")
+    str_data = "\n".join(rows)
+    
+    data_as_file = io.StringIO(str_data)
+
+    full_table_id = f"{project_id}.{schema['bq_dataset_name']}.{schema['bq_table_name']}"
+    table = client.get_table(full_table_id)
+
+    load_job_config = LoadJobConfig(
+        source_format="NEWLINE_DELIMITED_JSON"
+    )
+    load_job = client.load_table_from_file(
+        file_obj=data_as_file,
+        destination=table,
+        job_config=load_job_config
+    )
+    load_job.result()
+    print(f"Output rows: {load_job.output_rows}")
+    print(f"Errors: {load_job.errors}")
+    return load_job
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("file_path")
+    parser.add_argument("--overwrite", action="store_true")
+    parser.add_argument("--table-only", action="store_true")
+    args = parser.parse_args()
+
+    with open(args.file_path, "r") as o:
+        schema = json.load(o)
+
+    table = create_table(schema, overwrite=args.overwrite)
+
+    if not args.table_only:
+        load_job = load_table(schema)
+

--- a/oeps_backend/table_definitions/README.md
+++ b/oeps_backend/table_definitions/README.md
@@ -1,0 +1,31 @@
+# Table Schemas
+
+*this is a work-in-progress*
+
+The structure of these schema files is based on the [table schema](https://specs.frictionlessdata.io/table-schema) specification, published by [Frictionless Standards](https://specs.frictionlessdata.io), with a few additions aimed at use in Google BigQuery.
+
+For example, per table-schema, the `type` and `format` properties must follow the [table schema](https://specs.frictionlessdata.io/table-schema/#types-and-formats) spec, but a different set of data type values must be used for BigQuery, and these will be stored in `bg_data_type`.
+
+Note on spatial data: `table schema` only has `geojson` or `geopoint` as valid types. This means the spec doesn't really work for many common spatial formats (CSV with the geometries stored as WKT, for example).
+
+```
+{
+    "bq_dataset_name": "the name of the dataset in BigQuery to hold this table",
+    "bq_table_name": "this table's name as it will appeard in BigQuery",
+    "data_source": "relative path from data_local directory to CSV or SHP for this table",
+    "fields": [
+        {
+            "name": "name of field (e.g. column name)",
+            "title": "A nicer human readable label or title for the field",
+            "type": "A string specifying the type",
+            "format": "A string specifying a format",
+            "example": "An example value for the field",
+            "description": "A description for the field",
+            "constraints": {
+                // a constraints-descriptor
+            }
+            "bq_data_type": "a datatype string for use in BigQuery"
+        }
+    ]
+}
+```

--- a/oeps_backend/table_definitions/geom_counties.json
+++ b/oeps_backend/table_definitions/geom_counties.json
@@ -1,0 +1,30 @@
+{
+    "bq_dataset_name": "spatial",
+    "bq_table_name": "counties2018",
+    "data_source": "shp/counties2018-fixed2.shp",
+    "fields": [
+        {
+            "name": "geoid",
+            "title": "GeoId",
+            "type": "string",
+            "src_name": "GEOID",
+            "bq_data_type": "STRING",
+            "max_length": 5,
+            "zfill": true
+        },
+        {
+            "name": "name",
+            "title": "Name",
+            "type": "string",
+            "src_name": "NAME",
+            "bq_data_type": "STRING"
+        },
+        {
+            "name": "geom",
+            "title": "Geom",
+            "type": "string",
+            "src_name": "geometry",
+            "bq_data_type": "GEOGRAPHY"
+        }
+    ]
+}

--- a/oeps_backend/table_definitions/geom_states.json
+++ b/oeps_backend/table_definitions/geom_states.json
@@ -1,0 +1,28 @@
+{
+    "bq_dataset_name": "spatial",
+    "bq_table_name": "states2018",
+    "data_source": "shp/states2018.shp",
+    "fields": [
+        {
+            "name": "geoid",
+            "title": "GeoId",
+            "type": "string",
+            "src_name": "GEOID",
+            "bq_data_type": "STRING"
+        },
+        {
+            "name": "name",
+            "title": "Name",
+            "type": "string",
+            "src_name": "NAME",
+            "bq_data_type": "STRING"
+        },
+        {
+            "name": "geom",
+            "title": "Geom",
+            "type": "string",
+            "src_name": "geometry",
+            "bq_data_type": "GEOGRAPHY"
+        }
+    ]
+}

--- a/oeps_backend/table_definitions/geom_tracts.json
+++ b/oeps_backend/table_definitions/geom_tracts.json
@@ -1,0 +1,21 @@
+{
+    "bq_dataset_name": "spatial",
+    "bq_table_name": "tracts2018",
+    "data_source": "shp/tracts2018.shp",
+    "fields": [
+        {
+            "name": "geoid",
+            "title": "GeoId",
+            "type": "string",
+            "src_name": "GEOID",
+            "bq_data_type": "STRING"
+        },
+        {
+            "name": "geom",
+            "title": "Geom",
+            "type": "string",
+            "src_name": "geometry",
+            "bq_data_type": "GEOGRAPHY"
+        }
+    ]
+}

--- a/oeps_backend/table_definitions/geom_zctas.json
+++ b/oeps_backend/table_definitions/geom_zctas.json
@@ -1,0 +1,21 @@
+{
+    "bq_dataset_name": "spatial",
+    "bq_table_name": "zctas2018",
+    "data_source": "shp/zctas2018.shp",
+    "fields": [
+        {
+            "name": "geoid",
+            "title": "GeoId",
+            "type": "string",
+            "src_name": "ZCTA5CE10",
+            "bq_data_type": "STRING"
+        },
+        {
+            "name": "geom",
+            "title": "Geom",
+            "type": "string",
+            "src_name": "geometry",
+            "bq_data_type": "GEOGRAPHY"
+        }
+    ]
+}


### PR DESCRIPTION
Initial design and implementation of a workflow for loading datasets directly to Google BigQuery. A new script, `bq_load.py` must be passed a table definition file, from which it will

1. create a new dataset (if needed) and table from provided schema
2. load the dataset, shapefile or CSV, from the data source provided in the table definition

This pull request also includes four table definitions for the 2018 shapefiles (states, counties, zip code tabulation areas, and census tracts) that were included in the v1 release of OEPS.

All four tables load into BigQuery, but for one row in the counties shapefile that seems to error (all other counties load properly though).

closes #9 